### PR TITLE
Webhook processing: 202 response with empty body

### DIFF
--- a/src/web/api.go
+++ b/src/web/api.go
@@ -90,13 +90,13 @@ func WebhookHandler(c *gin.Context) {
 
 		ret = true
 	} else {
-		// HMAC signature is invalid: do not send [accepted] response
+		// HMAC signature is invalid
 		log.Println("HMAC signature is invalid")
 		ret = false
 	}
 
 	if ret {
-		c.String(200, "[accepted]")
+		c.Status(http.StatusAccepted)
 	} else {
 		c.String(401, "Invalid hmac signature")
 	}


### PR DESCRIPTION
The latest approach to accepting webhooks requires sending the response code 202 and an empty response body.

This PR updates all webhook handlers to implement the new approach.